### PR TITLE
Deep link

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject org.clojars.onaio/hatti "0.1.0-SNAPSHOT"
+(defproject org.clojars.onaio/hatti "0.1.1-SNAPSHOT"
   :description "A cljs dataview from your friends at Ona.io"
   :dependencies [;; CORE HATTI REQUIREMENTS
                  [org.clojure/clojure "1.6.0"]
@@ -16,10 +16,10 @@
                  [com.andrewmcveigh/cljs-time "0.2.3"]
                  ;; JS REQUIREMENTS
                  [cljsjs/moment "2.9.0-0"]
-                 [prabhasp/leaflet-cljs "0.7.3-SNAPSHOT"]
+                 [prabhasp/leaflet-cljs "0.7.3"]
                  [cljsjs/jquery "1.9.1-0"]
-                 [prabhasp/slickgrid-cljs "0.0.1-SNAPSHOT"]
-                 [prabhasp/osmtogeojson-cljs "2.2.5-SNAPSHOT"]
+                 [prabhasp/slickgrid-cljs "0.0.1"]
+                 [prabhasp/osmtogeojson-cljs "2.2.5-1"]
                  ;; TODO: make into cljs packages
                  [org.webjars/SlickGrid "2.1"]
                  ;; CLIENT REQUIREMENTS

--- a/project.clj
+++ b/project.clj
@@ -7,6 +7,7 @@
                  [sablono "0.3.1"]
                  [org.omcljs/om "0.8.8"]
                  [inflections "0.9.7"]
+                 [secretary "1.2.3"]
                  ;; CLJX
                  [com.keminglabs/cljx "0.6.0" :exclusions [org.clojure/clojure]]
                  ;; FOR CHARTS

--- a/src/cljs/hatti/map/utils.cljs
+++ b/src/cljs/hatti/map/utils.cljs
@@ -216,6 +216,15 @@
        #(when-not (is-clicked? marker)
           (apply-unclick-style marker))))
 
+(defn- re-render-map! [leaflet-map feature-layer]
+  "Re-renders map by invalidating leaflet size.
+   If map is zoomed out beyond layer-bounds, re-zooms to layer."
+  (let [map-bounds (.getBounds leaflet-map)
+        layer-bounds (.getBounds feature-layer)]
+    (.invalidateSize leaflet-map false)
+    (when-not (.contains layer-bounds map-bounds)
+      (.fitBounds leaflet-map layer-bounds))))
+
 (defn- load-geo-json
   "Create a map with the given GeoJSON data.
    Adds mouse events and centers on the geojson features."

--- a/src/cljs/hatti/routing.cljs
+++ b/src/cljs/hatti/routing.cljs
@@ -20,6 +20,3 @@
                         navigation
                         #(-> % .-token sec/dispatch!))
     (doto history (.setEnabled true))))
-
-
-

--- a/src/cljs/hatti/routing.cljs
+++ b/src/cljs/hatti/routing.cljs
@@ -1,0 +1,25 @@
+(ns hatti.routing
+  (:require [om.core :as om]
+            [secretary.core :as sec :refer-macros [defroute]]
+            [hatti.views.dataview :refer [activate-view!]]
+            [hatti.shared :as shared]
+            [goog.events :as events]
+            [goog.history.EventType :as EventType])
+  (:import goog.History))
+
+(defroute "/:view" {:keys [view]}
+  "Checks if this view is one of the allowed ones.
+  If so, switches the selected view via app-state."
+  (activate-view! view))
+
+(defn enable-dataview-routing! []
+  (let [history (History.)
+        navigation EventType/NAVIGATE]
+    (sec/set-config! :prefix "#")
+    (goog.events/listen history
+                        navigation
+                        #(-> % .-token sec/dispatch!))
+    (doto history (.setEnabled true))))
+
+
+

--- a/src/cljs/hatti/shared.cljs
+++ b/src/cljs/hatti/shared.cljs
@@ -33,7 +33,8 @@
   "An initial, empty, app-state, which can be modified to change dataviews."
   []
   (atom
-   {:views {:all [:map :table :chart :details]}
+   {:views {:all [:map :table :chart :details]
+            :selected :map}
     :map-page {:data []
                :submission-clicked {:data nil}
                :geofield {}}

--- a/src/cljs/hatti/views/table.cljs
+++ b/src/cljs/hatti/views/table.cljs
@@ -154,7 +154,7 @@
          (when filter-by
            (.setFilterArgs dataview (clj->js {:query filter-by}))
            (.refresh dataview))
-         (when (= re-render "table")
+         (when (= re-render :table)
            ;; need tiny wait (~16ms requestAnimationFrame delay) to re-render table
            (go (<! (timeout 20))
                (.resizeCanvas grid)


### PR DESCRIPTION
Deep linking v1, where `#/map` `#/table` `#/chart` and `#/details` are working.
See the [stolen sculptures demo on gh-pages](http://onaio.github.io/hatti/examples/stolen/#/chart) for an example. The link leads straight to the chart view.