### PR TITLE
Convert strings to date objects before use

### DIFF
--- a/phantom/unit-test.js
+++ b/phantom/unit-test.js
@@ -1,4 +1,3 @@
-
 var page = require("webpage").create();
 var url = phantom.args[0];
 

--- a/src/hatti/charting.cljc
+++ b/src/hatti/charting.cljc
@@ -43,7 +43,8 @@
   "Converts string to integer, for typ (int|date)."
   (case typ
     "int" parse-int
-    "date" #(let [l (tc/to-long %)] (when l (safe-floor (/ l millis-in-day))))))
+    "date" #(let [l (tc/to-long (new js/Date %))]
+              (when l (safe-floor (/ l millis-in-day))))))
 
 (defn int->str [typ &{:keys [digits]
                       :or   {digits 1}}]

--- a/src/hatti/charting.cljc
+++ b/src/hatti/charting.cljc
@@ -80,8 +80,7 @@
    metadata of this above value would be:
    {:bins ['1 to 2', '3 to 4', '5 to 6', '7 to 8', '9 to 10']}"
      [answers bins typ]
-     (let [numbers (->> answers
-                        (map (str->int typ)))
+     (let [numbers (map (str->int typ) answers)
            mx (reduce max (remove nil? numbers))
            mn (reduce min (remove nil? numbers))
            s (scale/linear :domain [mn mx] :range [0 (- bins (/ 1 10000))])

--- a/test/hatti/charting_test.cljs
+++ b/test/hatti/charting_test.cljs
@@ -1,0 +1,8 @@
+(ns hatti.charting-test
+  (:require-macros [cljs.test :refer [is deftest testing]])
+  (:require [hatti.charting :refer [str->int]]))
+
+(deftest str->int-test
+  (let [date->integer (str->int "date")]
+    (testing "returns a binnable value when given a date in string form"
+      (is (number? (date->integer "2015-01-12"))))))


### PR DESCRIPTION
This fixes "Invalid date" error, where `nil` values were being passed to `cljs-time.coerce/to-long` and the results passed to moment.js