### PR TITLE
Move map style functions to generic ns

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
       [path]
       (str "resources/public/js/lib/" path))
 
-(defproject onaio/hatti "0.1.20-refactor-style-utils-SNAPSHOT"
+(defproject onaio/hatti "0.1.20"
   :description "A cljs dataview from your friends at Ona.io"
   :license "Apache 2, see LICENSE"
   :url "https://github.com/onaio/hatti"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
       [path]
       (str "resources/public/js/lib/" path))
 
-(defproject onaio/hatti "0.1.19"
+(defproject onaio/hatti "0.1.20-refactor-style-utils-SNAPSHOT"
   :description "A cljs dataview from your friends at Ona.io"
   :license "Apache 2, see LICENSE"
   :url "https://github.com/onaio/hatti"

--- a/src/hatti/map/viewby.cljs
+++ b/src/hatti/map/viewby.cljs
@@ -4,7 +4,7 @@
             [hatti.utils :refer [safe-regex]]
             [hatti.charting :refer [evenly-spaced-bins]]
             [hatti.ona.forms :as form-utils]
-            [hatti.map.style :refer [answer->color grey]]
+            [hatti.utils.style :refer [answer->color grey]]
             [hatti.map.utils :as map-utils]))
 
 ;;;;; MAP

--- a/src/hatti/utils/style.cljs
+++ b/src/hatti/utils/style.cljs
@@ -49,8 +49,8 @@
        (apply merge)))
 
 (defn- style-map->color-map
-  [[answer style]]
-  {answer (:color style)})
+  [[answer {:keys [color]}]]
+  {answer color})
 
 (defn group-user-defined-colors-by-answer
   [field]

--- a/src/hatti/utils/style.cljs
+++ b/src/hatti/utils/style.cljs
@@ -1,4 +1,4 @@
-(ns hatti.map.style
+(ns hatti.utils.style
   (:require [clojure.string :refer [join split]]
             [hatti.ona.forms :as form-utils]))
 

--- a/src/hatti/utils/style.cljs
+++ b/src/hatti/utils/style.cljs
@@ -2,7 +2,9 @@
   (:require [clojure.string :refer [join split]]
             [hatti.ona.forms :as form-utils]))
 
-(def user-customizable-styles #{"color"})
+(def user-customizable-styles
+  "Set of CSS properties that can be modified by a user"
+  #{"color"})
 
 (def qualitative-palette
   "Saturated qualitative palette from colorbrewer.
@@ -27,6 +29,7 @@
   "#d9d9d9")
 
 (defn customizable-style?
+  "Check if a user can customize a style"
   [[style-name _]]
   (contains? user-customizable-styles style-name))
 
@@ -49,10 +52,12 @@
        (apply merge)))
 
 (defn- style-map->color-map
+  "Returns only the color property of the style map, with the answer as the key"
   [[answer {:keys [color]}]]
   {answer color})
 
 (defn group-user-defined-colors-by-answer
+  "Return a map of answers to their associated colors"
   [field]
   (->> field
        group-user-defined-styles-by-answer
@@ -78,6 +83,9 @@
     (form-utils/select-all? field) (repeat "#f30")))
 
 (defn answer->color
+  "Given a field and set of answers, return a mapping of answer to color
+   defaulting to an inbuilt palette if the field is not a select-one or
+   any of the choices lack an appearance attribute"
   [{:keys [children] :as field} answers]
   (cond
     (and (form-utils/select-one? field)

--- a/src/hatti/utils/style.cljs
+++ b/src/hatti/utils/style.cljs
@@ -54,7 +54,8 @@
 (defn- style-map->color-map
   "Returns only the color property of the style map, with the answer as the key"
   [[answer {:keys [color]}]]
-  {answer color})
+  (when color
+    {answer color}))
 
 (defn group-user-defined-colors-by-answer
   "Return a map of answers to their associated colors"
@@ -62,6 +63,9 @@
   (->> field
        group-user-defined-styles-by-answer
        (map style-map->color-map)
+       (remove nil?)
+       seq
+       vec
        (into {})))
 
 (defn field->colors

--- a/src/hatti/utils/style.cljs
+++ b/src/hatti/utils/style.cljs
@@ -41,7 +41,7 @@
        (into {})))
 
 (defn group-user-defined-styles-by-answer
-  "Return a map "
+  "Return a map of answer to associated CSS rules"
   [{:keys [children]}]
   (->> children
        (map (fn [{:keys [name appearance]}]

--- a/src/hatti/utils/style.cljs
+++ b/src/hatti/utils/style.cljs
@@ -87,8 +87,7 @@
    defaulting to an inbuilt palette if the field is not a select-one or
    any of the choices lack an appearance attribute"
   [{:keys [children] :as field} answers]
-  (cond
-    (and (form-utils/select-one? field)
-         (every? :appearance children))
+  (if (and (form-utils/select-one? field)
+           (every? :appearance children))
     (group-user-defined-colors-by-answer field)
-    :else (zipmap answers (field->colors field))))
+    (zipmap answers (field->colors field))))

--- a/src/hatti/views/map.cljs
+++ b/src/hatti/views/map.cljs
@@ -6,7 +6,7 @@
             [hatti.constants :refer [_id _rank]]
             [hatti.ona.forms :as f :refer [format-answer get-label get-icon]]
             [hatti.utils :refer [click-fn]]
-            [hatti.map.style :refer [grey]]
+            [hatti.utils.style :refer [grey]]
             [hatti.map.utils :as mu]
             [hatti.map.viewby :as vb]
             [hatti.shared :as shared]

--- a/test/hatti/map/viewby_test.cljs
+++ b/test/hatti/map/viewby_test.cljs
@@ -2,7 +2,7 @@
   (:require-macros [cljs.test :refer (is deftest testing)])
   (:require [cljs.test :as t]
             [hatti.test-utils :refer [remove-nil ordered-diff]]
-            [hatti.map.style :as style]
+            [hatti.utils.style :as style]
             [hatti.map.viewby :as vb]
             [hatti.views]))
 

--- a/test/hatti/utils/style_test.cljs
+++ b/test/hatti/utils/style_test.cljs
@@ -2,10 +2,10 @@
   (:require-macros [cljs.test :refer [is deftest testing]])
   (:require [clojure.string :refer [join]]
             [hatti.utils.style :refer [customizable-style?
-                                     get-css-rule-map
-                                     group-user-defined-colors-by-answer
-                                     group-user-defined-styles-by-answer
-                                     user-customizable-styles]]))
+                                       get-css-rule-map
+                                       group-user-defined-colors-by-answer
+                                       group-user-defined-styles-by-answer
+                                       user-customizable-styles]]))
 
 (def customizable-style [(first user-customizable-styles)
                          "style-definition"])

--- a/test/hatti/utils/style_test.cljs
+++ b/test/hatti/utils/style_test.cljs
@@ -1,7 +1,7 @@
-(ns hatti.map.style-test
+(ns hatti.utils.style-test
   (:require-macros [cljs.test :refer [is deftest testing]])
   (:require [clojure.string :refer [join]]
-            [hatti.map.style :refer [customizable-style?
+            [hatti.utils.style :refer [customizable-style?
                                      get-css-rule-map
                                      group-user-defined-colors-by-answer
                                      group-user-defined-styles-by-answer

--- a/test/hatti/views/map_test.cljs
+++ b/test/hatti/views/map_test.cljs
@@ -7,7 +7,7 @@
             [hatti.shared :refer [app-state]]
             [hatti.views :refer [map-viewby-legend map-geofield-chooser]]
             [hatti.views.map]
-            [hatti.map.style :refer [grey]]
+            [hatti.utils.style :refer [grey]]
             [hatti.map.utils :as mu]
             [hatti.map.viewby :as vb]
             [hatti.test-utils :refer [new-container! texts owner readonly]]

--- a/test/test_runner.cljs
+++ b/test/test_runner.cljs
@@ -2,7 +2,7 @@
   (:require
    [cljs.test :as test :refer-macros [run-tests] :refer [report]]
    [hatti.test-utils]
-   [hatti.map.style-test]
+   [hatti.utils.style-test]
    [hatti.map.utils-test]
    [hatti.map.viewby-test]
    [hatti.ona.forms-test]
@@ -28,7 +28,7 @@
        (run-tests
         (test/empty-env ::test/default)
         'hatti.test-utils
-        'hatti.map.style-test
+        'hatti.utils.style-test
         'hatti.map.utils-test
         'hatti.map.viewby-test
         'hatti.ona.forms-test


### PR DESCRIPTION
This refactor encourages re-use outside mapping contexts.