### PR TITLE
Photo gallery

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
       [path]
       (str "resources/public/js/lib/" path))
 
-(defproject onaio/hatti "0.3.5-photoswipe-SNAPSHOT"
+(defproject onaio/hatti "0.3.5"
   :description "A cljs dataview from your friends at Ona.io"
   :license "Apache 2, see LICENSE"
   :url "https://github.com/onaio/hatti"
@@ -25,7 +25,7 @@
                  ;; JS
                  [cljsjs/moment "2.10.6-4"]
                  [onaio/leaflet-cljs "0.7.3-SNAPSHOT"]
-                 [onaio/milia "0.3.21-SNAPSHOT"]
+                 [onaio/milia "0.3.21"]
                  [cljsjs/jquery "2.2.4-0"]
                  [cljsjs/oboe "2.1.2-1"]
                  [cljsjs/photoswipe "4.1.1-0"]

--- a/project.clj
+++ b/project.clj
@@ -25,8 +25,9 @@
                  ;; JS
                  [cljsjs/moment "2.10.6-4"]
                  [onaio/leaflet-cljs "0.7.3-SNAPSHOT"]
-                 [cljsjs/oboe "2.1.2-1"]
                  [cljsjs/jquery "2.2.4-0"]
+                 [cljsjs/oboe "2.1.2-1"]
+                 [cljsjs/photoswipe "4.1.1-0"]
                  [onaio/slickgrid-cljs "0.0.3"]
                  [prabhasp/osmtogeojson-cljs "2.2.5-1"]
                  [org.webjars/SlickGrid "2.1"]

--- a/project.clj
+++ b/project.clj
@@ -25,7 +25,7 @@
                  ;; JS
                  [cljsjs/moment "2.10.6-4"]
                  [onaio/leaflet-cljs "0.7.3-SNAPSHOT"]
-                 [onaio/milia "0.3.20"]
+                 [onaio/milia "0.3.21-SNAPSHOT"]
                  [cljsjs/jquery "2.2.4-0"]
                  [cljsjs/oboe "2.1.2-1"]
                  [cljsjs/photoswipe "4.1.1-0"]

--- a/project.clj
+++ b/project.clj
@@ -25,6 +25,7 @@
                  ;; JS
                  [cljsjs/moment "2.10.6-4"]
                  [onaio/leaflet-cljs "0.7.3-SNAPSHOT"]
+                 [onaio/milia "0.3.20"]
                  [cljsjs/jquery "2.2.4-0"]
                  [cljsjs/oboe "2.1.2-1"]
                  [cljsjs/photoswipe "4.1.1-0"]

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
       [path]
       (str "resources/public/js/lib/" path))
 
-(defproject onaio/hatti "0.3.4"
+(defproject onaio/hatti "0.3.5-photoswipe-SNAPSHOT"
   :description "A cljs dataview from your friends at Ona.io"
   :license "Apache 2, see LICENSE"
   :url "https://github.com/onaio/hatti"

--- a/src/hatti/constants.cljs
+++ b/src/hatti/constants.cljs
@@ -1,9 +1,14 @@
 (ns hatti.constants)
 
+(def _attachments "_attachments")
 (def _id "_id")
 (def _rank "_rank")
 (def _submission_time "_submission_time")
 (def _submitted_by "_submitted_by")
+
+;; Attachments keys
+(def medium-download-url "medium_download_url")
+(def small-download-url "small_download_url")
 
 ;; Google Sheets app-type.
 (def google-sheets "google_sheets")

--- a/src/hatti/constants.cljs
+++ b/src/hatti/constants.cljs
@@ -11,6 +11,7 @@
 (def download-url "download_url")
 (def medium-download-url "medium_download_url")
 (def small-download-url "small_download_url")
+(def mimetype "mimetype")
 
 ;; Google Sheets app-type.
 (def google-sheets "google_sheets")

--- a/src/hatti/constants.cljs
+++ b/src/hatti/constants.cljs
@@ -5,6 +5,7 @@
 (def _rank "_rank")
 (def _submission_time "_submission_time")
 (def _submitted_by "_submitted_by")
+(def photo "Photo")
 
 ;; Attachments keys
 (def download-url "download_url")

--- a/src/hatti/constants.cljs
+++ b/src/hatti/constants.cljs
@@ -7,6 +7,7 @@
 (def _submitted_by "_submitted_by")
 
 ;; Attachments keys
+(def download-url "download_url")
 (def medium-download-url "medium_download_url")
 (def small-download-url "small_download_url")
 

--- a/src/hatti/map/utils.cljs
+++ b/src/hatti/map/utils.cljs
@@ -513,7 +513,6 @@
   (let [{:keys [layer-type layout style]} (geotype->marker-style geofield)
         stops (om/get-state owner :stops)
         circle-border "point-casting"]
-    (.log js/console (js/JSON.stringify (clj->js geojson)))
     (when (or (-> geojson :features count pos?) tiles-url)
       (add-mapboxgl-source map id_string map-data)
       (add-mapboxgl-layer map id_string layer-type :layout layout)

--- a/src/hatti/ona/post_process.cljs
+++ b/src/hatti/ona/post_process.cljs
@@ -9,6 +9,8 @@
             [cljsjs.jquery]
             [osmtogeojson]))
 
+(def attachments-key "_attachments")
+
 ;; OSM POST-PROCESSING
 
 (defn ona-osm-link
@@ -87,6 +89,7 @@
                      (updater (:full-name osm-field))))))))
 
 ;; IMAGE POST-PROCESSING
+
 (defn url-obj
   "Calculate full image and thumbnail urls given attachment information."
   [media-obj]
@@ -101,14 +104,14 @@
   "Helper function for integrate attachments; returns a function from
    a filename to a `url-obj` (see specs in `url-obj` function)."
   [record attachments]
-  (let [attachments (or attachments (get record "_attachments"))
+  (let [attachments (or attachments (get record attachments-key))
         fnames (map #(last-url-param (get % "filename")) attachments)
         fname->urlobj (zipmap fnames (map url-obj attachments))]
     ;; If urlobj isn't found, we'll just return filename
     (fn [fname] (get fname->urlobj fname fname))))
 
 (defn integrate-attachments
-  "Inlines media data from within _attachments into each record."
+  "Inlines media data from within attachments-key into each record."
   [flat-form data & {:keys [attachments]}]
   (let [image-fields (filter forms/image? flat-form)]
     (for [record data]
@@ -119,7 +122,7 @@
                 image-fields)))))
 
 (defn integrate-attachments-in-repeats
-  "Inlines data from within _attachments into each datapoint within repeats."
+  "Inlines data from within attachments-key into each datapoint within repeats."
   [flat-form data]
   (let [repeat-fields (filter forms/repeat? flat-form)
         integrate (fn [record rpt-field]
@@ -129,7 +132,7 @@
                               (:children rpt-field)
                               (get record key)
                               :attachments
-                              (get record "_attachments")))))]
+                              (get record attachments-key)))))]
     (for [record data]
       (reduce integrate record repeat-fields))))
 

--- a/src/hatti/shared.cljs
+++ b/src/hatti/shared.cljs
@@ -37,7 +37,7 @@
   "An initial, empty, app-state, which can be modified to change dataviews."
   []
   (atom
-   {:views {:all [:overview :map :table :chart :saved-charts :settings]
+   {:views {:all [:overview :map :table :photos :chart :saved-charts :settings]
             :selected :overview
             :settings {:all [:form-info :settings :basemaps
                              :integrated-apps :media-files
@@ -117,14 +117,14 @@
                                    (.preventDefault event)))
             stringify #(if (keyword? %) (name %) (str %))]
         (html
-         [:div {:class "language-selector-inner"}
-          [:span {:class "dropdown drop-hover"}
-           [:i {:class "fa fa-globe" :style {:margin-right ".2em"}}]
+         [:div.language-selector-inner
+          [:span.dropdown.drop-hover
+           [:i.fa.fa-globe {:style {:margin-right ".2em"}}]
            [:span
             (if (f/english? current) "EN" (stringify current))]
-           [:i {:class "fa fa-angle-down" :style {:margin-left ".5em"}}]
-           [:ul {:class "submenu"}
+           [:i.fa.fa-angle-down {:style {:margin-left ".5em"}}]
+           [:ul.submenu
             (for [language all]
               [:li [:a {:href "#" :on-click (get-update-handler language)}
                     (stringify language)]])]]
-          [:div {:class "divider"}]])))))
+          [:div.divider]])))))

--- a/src/hatti/views/chart.cljs
+++ b/src/hatti/views/chart.cljs
@@ -62,16 +62,16 @@
       (let [form (om/get-shared owner [:flat-form])
             language (:current (om/observe owner (shared/language-cursor)))
             to-links (partial map #(field->link % language))]
-        (html [:div {:class "cfix" :id "chart-chooser"}
+        (html [:div.cfix#chart-chooser
                [:span "Add New Chart"]
-               [:div {:class "drop-hover dropdown-single" :id "chart-dropdown"}
-                [:a {:href "#" :class "pure-button btn-border t-red"}
+               [:div.drop-hover.dropdown-single#chart-dropdown
+                [:a.pure-button.btn-border.t-red {:href "#"}
                  "Select Field "]
-                [:ul {:id "chart-dropdown-menu" :class "submenu no-dot"}
-                 [:li [:span {:class "drop-header"} "Metadata"]]
+                [:ul#chart-dropdown-menu.submenu.no-dot
+                 [:li [:span.drop-header "Metadata"]]
                  (to-links (forms/meta-fields form
                                               :with-submission-details? true))
-                 [:li [:span {:class "drop-header"} "Questions"]]
+                 [:li [:span.drop-header "Questions"]]
                  (to-links (forms/non-meta-fields form))]]])))))
 
 (defmethod single-chart :default
@@ -88,17 +88,18 @@
         (html
          (if (= status :inactive)
            [:div]
-           [:div {:class "chart-holder"}
-            [:a {:on-click (click-fn
-                            #(put! shared/event-chan
-                                   {:field field :remove-chart true}))
-                 :class "btn-close right" :href "#"} "×"]
-            [:div {:class "chart-content"}
-             [:h3 {:class "chart-name"} (forms/get-label field language)]
-             [:div {:class "bar-chart"}
+           [:div.chart-holder
+            [:a.btn-close.right
+             {:on-click (click-fn
+                         #(put! shared/event-chan
+                                {:field field :remove-chart true}))
+              :href "#"} "×"]
+            [:div.chart-content
+             [:h3.chart-name (forms/get-label field language)]
+             [:div.bar-chart
               (if data
                 (-> data (make-chart language) :chart)
-                [:div [:i {:class "fa fa-cog fa-spin"}]])]]]))))))
+                [:div [:i.fa.fa-cog.fa-spin]])]]]))))))
 
 (defmethod list-of-charts :default
   [cursor owner]
@@ -107,7 +108,7 @@
     om/IRender
     (render [_]
       (html
-       [:div {:class "charts clearfix"}
+       [:div.charts.clearfix
         (for [field (:visible-charts cursor)]
           (om/build single-chart
                     {:data (get-in cursor [:chart-data (:name field)])}
@@ -127,6 +128,6 @@
     om/IRender
     (render [_]
       (html
-       [:div {:class "charts-ui"}
+       [:div.charts-ui
         (om/build chart-chooser nil)
         (om/build list-of-charts (:chart-page cursor))]))))

--- a/src/hatti/views/dataview.cljs
+++ b/src/hatti/views/dataview.cljs
@@ -25,15 +25,15 @@
   {:overview {:view :overview
               :label "Overview"
               :component overview-page}
-   :photos {:view :photos
-            :label "Photos"
-            :component photos-page}
    :map {:view :map
          :label "Map"
          :component map-page}
    :table {:view :table
            :label "Table"
            :component table-page}
+   :photos {:view :photos
+            :label "Photos"
+            :component photos-page}
    :chart {:view :chart
            :label "Charts"
            :component chart-page}

--- a/src/hatti/views/dataview.cljs
+++ b/src/hatti/views/dataview.cljs
@@ -79,8 +79,10 @@
           [:div.divider]
           (om/build dataview-actions dataset-id)])))))
 
-(defn activate-view! [view]
-  (let [view (keyword view)
+(defn activate-view!
+  "Strip off ampersand suffixes then switch to view if result is a valid view"
+  [view]
+  (let [view (keyword (or (last (re-find #"(.*?)&" view)) view))
         views (-> @shared/app-state :views :all)]
     (when (contains? (set views) view)
       (merge-into-app-state! shared/app-state

--- a/src/hatti/views/photos.cljs
+++ b/src/hatti/views/photos.cljs
@@ -84,18 +84,18 @@
               :let [photo (nth photos i)
                     caption (format "Submission %s" (:rank photo))]]
           [:td
-           [:figure {:itemprop "associatedMedia"
-                     :itemscope ""
-                     :itemtype "http://schema.org/ImageObject"}
+           [:figure {"itemProp" "associatedMedia"
+                     "itemScope" ""
+                     "itemType" "http://schema.org/ImageObject"}
             [:a {:href (:src photo)
-                 :itemprop "contentUrl"
+                 "itemProp" "contentUrl"
                  :data-size (format "%sx%s" width-px width-px)
                  :on-click #(on-thumbnail-click % owner)}
              [:img {:src (:thumb photo)
-                    :itemprop "thumbnail"
+                    "itemProp" "thumbnail"
                     (keyword data-pswp-id) i
                     :alt caption}]]
-            [:figcaption {:itemprop "caption description"} caption]]]))))
+            [:figcaption {"itemProp" "caption description"} caption]]]))))
 
 (defmethod photos-page :default
   [{:keys [dataset-info]} owner]
@@ -141,7 +141,7 @@
             {:title "Next (arrow right)"}]
            [:div.pswp__caption
             [:div.pswp__caption__center]]]]]
-        [:div.gallery {:itemscope ""
-                       :itemtype "http://schema.org/ImageGallery"}
+        [:div.gallery {"itemScope" ""
+                       "itemType" "http://schema.org/ImageGallery"}
          [:table
           (build-photo-gallery photos owner)]]]))))

--- a/src/hatti/views/photos.cljs
+++ b/src/hatti/views/photos.cljs
@@ -6,6 +6,7 @@
             [om.core :as om :include-macros true]
             [sablono.core :refer-macros [html]]
             [hatti.constants :as constants]
+            [hatti.shared :as shared]
             [hatti.views :refer [photos-page]]
             [milia.utils.images :refer [resize-image]]
             [milia.utils.remote :as remote]))
@@ -165,11 +166,18 @@
      [:figcaption {"itemProp" "caption description"} title]]))
 
 (defmethod photos-page :default
-  [{:keys [data] {:keys [num_of_submissions]} :dataset-info} owner]
+  [{{:keys [num_of_submissions]} :dataset-info} owner]
   "Om component for the photos page."
   (reify
-    om/IRender
-    (render [_]
+    om/IInitState
+    (init-state [_]
+      ;; Use map-page data because it is not paged, like the table data
+      (select-keys @shared/app-state [:map-page :data]))
+    om/IWillReceiveProps
+    (will-receive-props [_ next-props]
+      (om/set-state! owner :data (-> @shared/app-state :map-page :data)))
+    om/IRenderState
+    (render-state [_ {:keys [data]}]
       (let [photos (build-photos data)]
         (html
          [:div.tab-content

--- a/src/hatti/views/photos.cljs
+++ b/src/hatti/views/photos.cljs
@@ -1,12 +1,78 @@
 (ns hatti.views.photos
-  (:require [om.core :as om :include-macros true]
+  (:require [cljsjs.photoswipe]
+            [cljsjs.photoswipe-ui-default]
+            [clojure.string :refer [replace]]
+            [om.core :as om :include-macros true]
             [sablono.core :refer-macros [html]]
-            [hatti.views :refer [photos-page]]))
+            [hatti.ona.post-process :refer [attachments-key]]
+            [hatti.shared :as hatti-shared]
+            [hatti.views :refer [photos-page]]
+            [milia.utils.remote :refer [make-url]]))
+
+(def medium-download-url "medium_download_url")
+(def width-px 400)
+
+(defn build-photos
+  "Build photos for photoswipe from a set of form data."
+  [data]
+  (flatten
+   (for [datum data
+         :let [attachments (get datum attachments-key)]
+         :when (seq attachments)]
+     (for [attachment attachments]
+       {:src (make-url (replace (get attachment medium-download-url)
+                                #"/api/v1" ""))
+        :w width-px :h width-px}))))
 
 (defmethod photos-page :default
   [{:keys [dataset-info]} owner]
   "Om component for the photos page."
-  (om/component
-   (html
-    [:div.container
-     [:p "This is the default photos page holder."]])))
+  (reify
+    om/IInitState
+    (init-state [_]
+      {:photos (build-photos (:data @hatti-shared/app-state))})
+    om/IRenderState
+    (render-state [_ {:keys [photos]}]
+      (html
+       [:div.container
+        [:div.pswp {:role "dialog" :aria-hidden "true" :tab-index "-1"}
+         [:div.pswp__bg]
+         [:div.pswp__scroll-wrap
+          [:div.pswp__container
+           [:div.pswp__item]
+           [:div.pswp__item]
+           [:div.pswp__item]]
+          [:div.pswp__ui.pswp__ui--hidden
+           [:div.pswp__top-bar
+            [:div.pswp__counter]
+            [:button.pswp__button.pswp__button--close
+             {:title "Close (Esc)"}]
+            [:button.pswp__button.pswp__button--share
+             {:title "Share"}]
+            [:button.pswp__button.pswp__button--fs
+             {:title "Toggle fullscreen"}]
+            [:button.pswp__button.pswp__button--zoom
+             {:title "Zoom in/out"}]
+            [:div.pswp__preloader
+             [:div.pswp__preloader__icn
+              [:div.pswp__preloader__cut
+               [:div.pswp__preloader__donut]]]]]
+           [:div.pswp__share-modal.pswp__share-modal--hidden.pswp__single-tap
+            [:div.pswp__share-tooltip]]
+           [:button.pswp__button.pswp__button--arrow--left
+            {:title "Previous (arrow left)"}]
+           [:button.pswp__button.pswp__button--arrow--right
+            {:title "Next (arrow right)"}]
+           [:div.pswp__caption
+            [:div.pswp__caption__center]]]]]
+        ]))
+    om/IDidMount
+    (did-mount [_]
+      (let [pswp-element (first (.querySelectorAll js/document ".pswp"))
+            options {:index 0 ;; start at the first slide
+                     }
+            gallery (js/PhotoSwipe. pswp-element
+                                    js/PhotoSwipeUI_Default
+                                    (clj->js (om/get-state owner :photos))
+                                    (clj->js options))]
+        (.init gallery)))))

--- a/src/hatti/views/photos.cljs
+++ b/src/hatti/views/photos.cljs
@@ -89,24 +89,20 @@
 (defn- build-photo-gallery
   "Build markup with actions for a photo gallery."
   [photos owner]
-  (map #(vector :tr %)
-       (partition-all
-        num-columns
-        (for [i (-> photos count range)
-              :let [{:keys [title] :as photo} (nth photos i)]]
-          [:td
-           [:figure {"itemProp" "associatedMedia"
-                     "itemScope" ""
-                     "itemType" "http://schema.org/ImageObject"}
-            [:a {:href (:src photo)
-                 "itemProp" "contentUrl"
-                 :data-size (format "%sx%s" width-px width-px)
-                 :on-click #(on-thumbnail-click % photos)}
-             [:img {:src (:thumb photo)
-                    "itemProp" "thumbnail"
-                    (keyword data-pswp-id) i
-                    :alt title}]]
-            [:figcaption {"itemProp" "caption description"} title]]]))))
+  (for [i (-> photos count range)
+        :let [{:keys [title] :as photo} (nth photos i)]]
+    [:figure {"itemProp" "associatedMedia"
+              "itemScope" ""
+              "itemType" "http://schema.org/ImageObject"}
+     [:a {:href (:src photo)
+          "itemProp" "contentUrl"
+          :data-size (format "%sx%s" width-px width-px)
+          :on-click #(on-thumbnail-click % photos)}
+      [:img {:src (:thumb photo)
+             "itemProp" "thumbnail"
+             (keyword data-pswp-id) i
+             :alt title}]]
+     [:figcaption {"itemProp" "caption description"} title]]))
 
 (defmethod photos-page :default
   [{:keys [data] {:keys [num_of_submissions]} :dataset-info} owner]
@@ -116,7 +112,7 @@
     (render [_]
       (let [photos (build-photos data)]
         (html
-         [:div.container
+         [:div.tab-content
           (cond
             (or (zero? num_of_submissions)
                 (and (seq data) (empty? photos)))

--- a/src/hatti/views/photos.cljs
+++ b/src/hatti/views/photos.cljs
@@ -122,18 +122,17 @@
             result
             (map-indexed
              (fn [j attachment]
-               (let [download-url (get attachment constants/download-url)
-                     thumb (or (get attachment constants/small-download-url)
-                               download-url)
-                     thumb-resized (resize-image (make-url thumb)
-                                                 thumb-width-px
-                                                 thumb-width-px)]
+               (let [download-url (make-url (get attachment
+                                                 constants/download-url))
+                     thumbnail (resize-image download-url
+                                             thumb-width-px
+                                             thumb-width-px)]
                  {:src (resize-image (make-url download-url)
                                      width-px
                                      width-px)
-                  :original-src (make-url download-url)
-                  :msrc thumb-resized
-                  :thumb thumb-resized
+                  :original-src download-url
+                  :msrc thumbnail
+                  :thumb thumbnail
                   :title (format "%s/%s | Submission %s"
                                  (+ photo-index j) total rank)
                   :date (get datum constants/_submission_time)

--- a/src/hatti/views/photos.cljs
+++ b/src/hatti/views/photos.cljs
@@ -102,7 +102,7 @@
    submission and not to the attachments list, use the information attached
    directly to the submission."
   [data]
-  (let [data-with-attachments (keep #(extract-images %) data)
+  (let [data-with-attachments (keep extract-images data)
         total (reduce #(+ %1 (count (get %2 constants/_attachments)))
                       0 data-with-attachments)]
     (loop [data-left data-with-attachments

--- a/src/hatti/views/photos.cljs
+++ b/src/hatti/views/photos.cljs
@@ -23,7 +23,7 @@
 
 (defn- open-photoswipe
   "Initiate photoswipe using the index of the image that was just clicked on."
-  [index owner]
+  [index photos]
   (let [pswp-element (first (.querySelectorAll js/document
                                                (str "." pswp-gallery-class)))
         options {:index (int index)
@@ -45,16 +45,16 @@
                       :w (.-width rect)}))}
         gallery (js/PhotoSwipe. pswp-element
                                 js/PhotoSwipeUI_Default
-                                (clj->js (om/get-state owner :photos))
+                                (clj->js photos)
                                 (clj->js options))]
     (.init gallery)))
 
 (defn- on-thumbnail-click
   "Actions to perform on thumbnail click."
-  [event owner]
+  [event photos]
   (.preventDefault event)
   (open-photoswipe (.getAttribute (.-target event) data-pswp-id)
-                   owner))
+                   photos))
 
 (defn- build-photos
   "Build photos for photoswipe from a set of form data."
@@ -90,7 +90,7 @@
             [:a {:href (:src photo)
                  "itemProp" "contentUrl"
                  :data-size (format "%sx%s" width-px width-px)
-                 :on-click #(on-thumbnail-click % owner)}
+                 :on-click #(on-thumbnail-click % photos)}
              [:img {:src (:thumb photo)
                     "itemProp" "thumbnail"
                     (keyword data-pswp-id) i

--- a/src/hatti/views/table.cljs
+++ b/src/hatti/views/table.cljs
@@ -367,7 +367,7 @@
   [app-state owner]
   (om/component
    (html
-    [:div {:class "topbar"}
+    [:div.topbar
      [:div {:id pager-id}]
      (om/build label-changer nil)
      (om/build table-search app-state)
@@ -437,9 +437,9 @@
                                                    #{:delete-record! :role})
                                       {:view :table})})
               (om/build table-header app-state)
-              [:div {:id table-id :class "slickgrid"}
+              [:div.slickgrid {:id table-id}
                (if (and no-data? (zero? num_of_submissions))
-                 [:span {:class "empty-state"} "No data"]
+                 [:p.alert.alert-warning "No data"]
                  [:span
                   [:i.fa.fa-spinner.fa-pulse] "Loading..."])]]))))
       om/IDidMount

--- a/test/hatti/views/chart_test.cljs
+++ b/test/hatti/views/chart_test.cljs
@@ -19,7 +19,7 @@
 (def chart-get-mock #(let [c (chan)] (put! c {:body nil}) c))
 
 (defn- chart-container
-  "Returns a container in which a map component has been rendered.
+  "Returns a container in which a chart component has been rendered.
    `data` arg is directly passed into the component as its cursor."
   [form]
   (let [cont (new-container!)

--- a/test/hatti/views/photos_test.cljs
+++ b/test/hatti/views/photos_test.cljs
@@ -1,0 +1,59 @@
+(ns hatti.views.photos-test
+  (:require-macros [cljs.test :refer (is deftest testing)]
+                   [dommy.core :refer [sel sel1]])
+  (:require [cljs.test :as t]
+            [cljs.core.async :refer [chan]]
+            [dommy.core :as dommy]
+            [hatti.constants :as constants]
+            [hatti.shared :as shared]
+            [hatti.test-utils :refer [new-container!]]
+            [hatti.views :refer [photos-page]]
+            [hatti.views.photos :refer [extract-images]]
+            [hatti.shared-test :refer
+             [fat-form no-data small-fat-data data-gen]]
+            [om.core :as om :include-macros true]))
+
+(def photos-form (take 4 fat-form))
+
+(defn- photo-container
+  "Returns a container in which a photo component has been rendered.
+   `data` arg is directly passed into the component as its cursor."
+  [form]
+  (let [cont (new-container!)
+        arg {:shared {:flat-form form
+                      :event-chan (chan)}
+             :target cont}]
+    (om/root photos-page shared/app-state arg)
+    cont))
+
+(deftest photos-render-properly
+  (let [container (photo-container photos-form)]
+    (testing "renders no photos properly"
+      (is (re-find #"no photos" (-> container (sel1 :p) dommy/text))))))
+
+(deftest extract-images-restricts-properly
+  (testing "return nil if photo but no download-url"
+    (is (= nil (extract-images {constants/photo {}}))))
+  (let [datum {constants/photo {(keyword constants/download-url) :url}}]
+    (testing "return argument if photo and download-url"
+      (is (= datum (extract-images datum)))))
+  (testing "return nil if neither attachments or photo"
+    (is (= nil (extract-images {:key :value}))))
+  (testing "return nil if no attachments"
+    (is (= nil (extract-images {constants/_attachments []}))))
+  (testing "return nil if attachments and no download-url"
+    (is (= nil (extract-images {constants/_attachments [{:key :value}]}))))
+  (let [datum {constants/_attachments [{constants/download-url :url}]}]
+    (testing "return argument if attachments and download-url"
+      (is (= datum (extract-images datum)))))
+  (let [datum {constants/_attachments [{constants/download-url :url}
+                                       {:key :value}]}]
+    (testing "return only attachments with download-url"
+      (is (= {constants/_attachments [{constants/download-url :url}]}
+             (extract-images datum)))))
+  (let [datum {constants/_attachments [{constants/download-url :url}
+                                       {constants/download-url :video-url
+                                        constants/mimetype "video/mp4"}]}]
+    (testing "return only attachments with download-url"
+      (is (= {constants/_attachments [{constants/download-url :url}]}
+             (extract-images datum))))))

--- a/test/test_runner.cljs
+++ b/test/test_runner.cljs
@@ -11,6 +11,7 @@
    [hatti.views.chart-test]
    [hatti.views.dataview-test]
    [hatti.views.map-test]
+   [hatti.views.photos-test]
    [hatti.views.record-test]
    [hatti.views.table-test]
    [hatti.shared-test]))
@@ -37,6 +38,7 @@
         'hatti.views.chart-test
         'hatti.views.dataview-test
         'hatti.views.map-test
+        'hatti.views.photos-test
         'hatti.views.record-test
         'hatti.views.table-test
         'hatti.shared-test))


### PR DESCRIPTION
Todos:

* [x] create a gallery
  * using the sample HTML and code here, http://photoswipe.com/documentation/getting-started.html
  * do not use the loop to find index method, use a data attr with the index
  * the JavaScript example at the bottom looks inefficient, like it can be cleaned up
  * might need to add more details to `:photos` state key from data in `build-photos` function
* [x] you have to click on table then on photos to get the photos tab, I forget why this happens, but I've seen it before, something about pre-loading I think
* [x] put on feature snapshot for QA

Zebra loads this using this branch: https://github.com/onaio/zebra/compare/3906-photos?expand=1

require for https://github.com/onaio/zebra/issues/3906 (use checkouts)