### PR TITLE
Add version as a meta field

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   [path]
   (str "resources/public/js/lib/" path))
 
-(defproject onaio/hatti "0.3.17"
+(defproject onaio/hatti "0.3.17-SNAPSHOT"
   :description "A cljs dataview from your friends at Ona.io"
   :license "Apache 2, see LICENSE"
   :url "https://github.com/onaio/hatti"

--- a/src/hatti/ona/forms.cljs
+++ b/src/hatti/ona/forms.cljs
@@ -100,7 +100,9 @@
 
 (defn meta?
   [field]
-  (or (field-name-in-set? #{"meta" "instanceID"} field)
+  (or (field-name-in-set? #{"meta"
+                            "instanceID"
+                            "__version__"} field)
       (field-type-in-set? #{"deviceid"
                             "end"
                             "imei"


### PR DESCRIPTION
Fields with label "__version__" are meta fields.

closes #184 
