### PR TITLE
Change photo tab download link on scroll

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   [path]
   (str "resources/public/js/lib/" path))
 
-(defproject onaio/hatti "0.3.18-SNAPSHOT"
+(defproject onaio/hatti "0.3.18-change-photo-tab-download-link-on-scroll-SNAPSHOT"
   :description "A cljs dataview from your friends at Ona.io"
   :license "Apache 2, see LICENSE"
   :url "https://github.com/onaio/hatti"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   [path]
   (str "resources/public/js/lib/" path))
 
-(defproject onaio/hatti "0.3.18-change-photo-tab-download-link-on-scroll-SNAPSHOT"
+(defproject onaio/hatti "0.3.18-SNAPSHOT"
   :description "A cljs dataview from your friends at Ona.io"
   :license "Apache 2, see LICENSE"
   :url "https://github.com/onaio/hatti"

--- a/src/hatti/views/photos.cljs
+++ b/src/hatti/views/photos.cljs
@@ -48,9 +48,11 @@
 
 (defn full-url-from-active-image
   []
-  (.getAttribute
-   (.querySelector js/document "img.pswp__img.pswp__img--placeholder")
-   "src"))
+  (last
+   (re-find #"/(http.*)"
+            (.getAttribute
+             (.querySelector js/document "img.pswp__img.pswp__img--placeholder")
+             "src"))))
 
 ;;; We use strings instead of keywords below because keywords are forced to
 ;;; lower-case. We use js-obj to avoid additional conversion costs.

--- a/test/hatti/views/photos_test.cljs
+++ b/test/hatti/views/photos_test.cljs
@@ -82,9 +82,8 @@
   (let [img (.createElement js/document "img")
         container (new-container! "active-image")
         active-image-src "https://the-url"]
-    (.setAttribute img "class" "pswp__img")
+    (.setAttribute img "class" "pswp__img pswp__img--placeholder")
     (.setAttribute img "src" (resize-image active-image-src 100))
     (dommy/append! (sel1 js/document "#active-image") img)
     (testing "strips last url"
-      (is (= (full-url-from-active-image)
-             active-image-src)))))
+      (is (= (full-url-from-active-image) active-image-src)))))


### PR DESCRIPTION
Look for `*--placeholder` and not `#active-tab` in the query selector to extract the download link.