### PR TITLE
Repeats should load layers for geopoint and geotrace.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   [path]
   (str "resources/public/js/lib/" path))
 
-(defproject onaio/hatti "0.3.26-SNAPSHOT"
+(defproject onaio/hatti "0.3.26"
   :description "A cljs dataview from your friends at Ona.io"
   :license "Apache 2, see LICENSE"
   :url "https://github.com/onaio/hatti"

--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   [path]
   (str "resources/public/js/lib/" path))
 
-(defproject onaio/hatti "0.3.25"
+(defproject onaio/hatti "0.3.26-SNAPSHOT"
   :description "A cljs dataview from your friends at Ona.io"
   :license "Apache 2, see LICENSE"
   :url "https://github.com/onaio/hatti"

--- a/src/hatti/map/utils.cljs
+++ b/src/hatti/map/utils.cljs
@@ -526,15 +526,17 @@
 
 (defn geotype->marker-style
   "Get marker style for field type."
-  [field]
+  [{:keys [children] :as field}]
   (cond
     (f/geoshape? field) {:layer-type "fill" :style :fill}
     (f/osm? field) {:layer-type "fill" :style :fill}
     (or
      (f/geotrace? field)
-     (f/repeat? field)) {:layer-type "line" :style :line
-                         :layout {:line-join "round"
-                                  :line-cap "round"}}
+     (and (f/repeat? field)
+          (f/geotrace? (first children))))
+    {:layer-type "line" :style :line
+     :layout {:line-join "round"
+              :line-cap "round"}}
     :else {:layer-type "circle" :style :point}))
 
 (defn filter-selected-features

--- a/src/hatti/map/utils.cljs
+++ b/src/hatti/map/utils.cljs
@@ -528,15 +528,13 @@
   "Get marker style for field type."
   [{:keys [children] :as field}]
   (cond
-    (f/geoshape? field) {:layer-type "fill" :style :fill}
-    (f/osm? field) {:layer-type "fill" :style :fill}
-    (or
-     (f/geotrace? field)
-     (and (f/repeat? field)
-          (f/geotrace? (first children))))
-    {:layer-type "line" :style :line
-     :layout {:line-join "round"
-              :line-cap "round"}}
+    (or (f/geoshape? field) (f/osm? field)) {:layer-type "fill" :style :fill}
+    (or (f/geotrace? field)
+        (and (f/repeat? field)
+             (f/geotrace? (first children)))) {:layer-type "line"
+                                               :style :line
+                                               :layout {:line-join "round"
+                                                        :line-cap  "round"}}
     :else {:layer-type "circle" :style :point}))
 
 (defn filter-selected-features

--- a/test/hatti/map/utils_test.cljs
+++ b/test/hatti/map/utils_test.cljs
@@ -43,6 +43,25 @@
     (is (not= nil (sel1 map-id :.leaflet-control-zoom)))
     (is (not= nil (sel1 map-id :.leaflet-control-layers)))))
 
+(deftest test-geotype->marker-style
+  (testing "Returns the exptected marker style for a given goetype"
+    (is (= (mu/geotype->marker-style {:type "geoshape"})
+           {:layer-type "fill" :style :fill}))
+    (is (= (mu/geotype->marker-style {:type "osm"})
+           {:layer-type "fill" :style :fill}))
+    (is (= (mu/geotype->marker-style {:type "geotrace"})
+           {:layer-type "line"
+            :style :line
+            :layout {:line-join "round"
+                     :line-cap  "round"}}))
+    (is (= (mu/geotype->marker-style {:type "repeat" :children '({:type "geotrace"})})
+           {:layer-type "line"
+            :style :line
+            :layout {:line-join "round"
+                     :line-cap  "round"}}))
+    (is (= (mu/geotype->marker-style {:type "anything else"})
+           {:layer-type "circle" :style :point}))))
+
 (deftest loading-and-marker-actions
   (let [chan (chan)
         N 10

--- a/test/hatti/map/utils_test.cljs
+++ b/test/hatti/map/utils_test.cljs
@@ -54,7 +54,8 @@
             :style :line
             :layout {:line-join "round"
                      :line-cap  "round"}}))
-    (is (= (mu/geotype->marker-style {:type "repeat" :children '({:type "geotrace"})})
+    (is (= (mu/geotype->marker-style {:type "repeat"
+                                      :children '({:type "geotrace"})})
            {:layer-type "line"
             :style :line
             :layout {:line-join "round"


### PR DESCRIPTION
In questions with repeats check the `children` and only use the `"line"` layer when the type is geotrace and use the circle as the default layer.