### PR TITLE
Add new all media received metadata

### DIFF
--- a/src/hatti/constants.cljs
+++ b/src/hatti/constants.cljs
@@ -41,3 +41,14 @@
 (def hexbin-cell-width 60)
 (def min-count-color "#f2f5fc")
 (def max-count-color "#08519c")
+
+(def failed-media-upload-error-message
+  "This media file was not uploaded successfully.")
+
+(def failed-media-upload-help-url
+  "knowledge-base/#")
+
+(defn help-base-url
+  "Define a help URL"
+  [suffix]
+  (str "http://help.ona.io/" suffix))

--- a/src/hatti/constants.cljs
+++ b/src/hatti/constants.cljs
@@ -7,6 +7,7 @@
 (def _notes "_notes")
 (def _rank "_rank")
 (def _submission_time "_submission_time")
+(def _media_all_received "_media_all_received")
 (def _submitted_by "_submitted_by")
 (def photo "Photo")
 

--- a/src/hatti/ona/forms.cljs
+++ b/src/hatti/ona/forms.cljs
@@ -1,8 +1,6 @@
 (ns hatti.ona.forms
   (:require [chimera.js-interop :refer [format]]
             [chimera.urls :refer [last-url-param]]
-            [ona.utils.urls :as urls]
-            [ona.utils.i18n :refer [translate]]
             [chimera.date :as chimera-date]
             [cljs.pprint :refer [cl-format]]
             [clojure.string :as string]
@@ -10,7 +8,10 @@
                                      _submitted_by
                                      _last_edited
                                      _id
-                                     _media_all_received]]))
+                                     _media_all_received
+                                     help-base-url
+                                     failed-media-upload-help-url
+                                     failed-media-upload-error-message]]))
 
 ;; CONSTANTS
 (def currency-regex #"£|$")
@@ -40,7 +41,7 @@
 (def media_received_field {:name      _media_all_received
                            :full-name _media_all_received
                            :label     "All media received?"
-                           :type      "boolean"})
+                           :type      "text"})
 
 (def extra-submission-details [last_edited
                                submission-time-field
@@ -224,17 +225,17 @@
 
 (defn media-files-upload-error-component
   "Displays tip question and tooltip msg for failed media files uploads"
-  [answer & {:keys [hlp-url translation-txt record-modal?]}]
+  [answer & {:keys [help-url error-message record-modal?]}]
   (if record-modal?
     [:span.image-name answer
-     [:a.tooltip {:href hlp-url :target "_blank"}
-      [:span.tip-info translation-txt]
+     [:a.tooltip {:href help-url :target "_blank"}
+      [:span.tip-info error-message]
       [:span.tip-question "?"]]]
     (format "<span class='image-name'> %s </span>
           <a class='tooltip' href=%s target='_blank'>
           <span class='tip-info'>%s</span>
           <span class='tip-question'>?</span></a>"
-            answer hlp-url translation-txt)))
+            answer help-url error-message)))
 
 (defn format-answer
   "String representation for a particular field datapoint (answer).
@@ -264,21 +265,16 @@
     (or (image? field)
         (video? field)) (let [image (:download_url answer)
                               thumb (or (:small_download_url answer) image)
-                              media-upload-fail-hlp-url
-                              urls/media-upload-fail-during-submission-help
-                              media-upload-fail-translation-txt
-                              (translate
-                               :table-data-view-page/media-upload-fail-err-msg)
                               fname (last-url-param (:filename answer))]
                           (cond
                             (and (string? answer)
                                  (not= answer "null") (nil? thumb))
                             (media-files-upload-error-component
                              answer
-                             :hlp-url
-                             media-upload-fail-hlp-url
-                             :translation-txt
-                             media-upload-fail-translation-txt
+                             :help-url
+                             (help-base-url failed-media-upload-help-url)
+                             :error-message
+                             failed-media-upload-error-message
                              :record-modal?
                              record-modal?)
                             (= answer "null") answer

--- a/test/hatti/ona/forms_test.cljs
+++ b/test/hatti/ona/forms_test.cljs
@@ -163,10 +163,12 @@
                     :small_download_url "THUMB.jpg"}
             image3 {:filename "foo/bar.jpg"
                     :download_url "IMAGE.jpg"}
-            txt-link (forms/format-answer q-img image2 :compact? true)]
+            txt-link (forms/format-answer q-img image2 :compact? true)
+            tooltip-error-msg (forms/format-answer q-img image1)]
         (is (= (forms/format-answer q-img nil) forms/no-answer))
         (is (= (forms/format-answer q-img "") forms/no-answer))
-        (is (= (forms/format-answer q-img image1) "bar.jpg"))
+        (is (re-find #"This media file was not uploaded successfully."
+                     tooltip-error-msg))
         (is (= (forms/format-answer q-img image2)
                [:a {:href "IMAGE.jpg" :target "_blank"}
                 [:img {:width "80px" :src "THUMB.jpg"}]]))


### PR DESCRIPTION
This Pr will add a new column containing the `_media_all_received` and also add a tooltip message on the right side of table records for media files that were not successfully uploaded.